### PR TITLE
Allow overriding of options with HTML data attributes where provided

### DIFF
--- a/jquery.easy-pie-chart.js
+++ b/jquery.easy-pie-chart.js
@@ -178,6 +178,7 @@ Thanks to Philip Thrasher for the jquery plugin boilerplate for coffee script
     return $.each(this, function(i, el) {
       var $el;
       $el = $(el);
+      $.extend(options, $el.data());
       if (!$el.data('easyPieChart')) {
         return $el.data('easyPieChart', new $.easyPieChart(el, options));
       }


### PR DESCRIPTION
This way individual charts could force a certain appearance, etc over the global scheme. Basically the order of dominance would be data-attributes, javascript-provided options, defaults; each falling back to the next least dominant (such as the current defaults are implemented).
