### PR TITLE
Date.now() doesn't work on IE < IE9. Fixing it.

### DIFF
--- a/jquery.easy-pie-chart.coffee
+++ b/jquery.easy-pie-chart.coffee
@@ -117,6 +117,14 @@ Thanks to Philip Thrasher for the jquery plugin boilerplate for coffee script
     animateLine = (from, to) =>
       @options.onStart.call @
       @percentage = to
+
+      # Setting Date.now for IE < IE9
+      if (!Date.now) {
+        Date.now = function() {
+          return new Date().valueOf();
+        }
+      }
+
       startTime = Date.now()
       anim = () =>
         process = Date.now() - startTime

--- a/jquery.easy-pie-chart.js
+++ b/jquery.easy-pie-chart.js
@@ -128,6 +128,11 @@ Thanks to Philip Thrasher for the jquery plugin boilerplate for coffee script
       var anim, startTime;
       _this.options.onStart.call(_this);
       _this.percentage = to;
+      if (!Date.now) {
+        Date.now = function() {
+          return new Date().valueOf();
+        }
+      }
       startTime = Date.now();
       anim = function() {
         var currentValue, process;


### PR DESCRIPTION
Setting Date.now to be new Date().valueOf, if it is not defined.
