### PR TITLE
	scope.$watch()'s callback is function(newValue, oldValue) not function(...

### DIFF
--- a/src/angular.directive.js
+++ b/src/angular.directive.js
@@ -1,7 +1,7 @@
 // Angular directives for easyPieChart
 if ((typeof(angular) === 'object') && (typeof(angular.version) === 'object')) {
 	angular.module('easypiechart',[])
-	.directive('easypiechart', ['$timeout', function($timeout) {
+	.directive('easypiechart', [function() {
 		return {
 			restrict: 'A',
 			require: '?ngModel',
@@ -34,17 +34,8 @@ if ((typeof(angular) === 'object') && (typeof(angular.version) === 'object')) {
 				}
 
 				// on change of value
-				var timer = null;
-				scope.$watch('percent', function(oldVal, newVal) {
+				scope.$watch('percent', function(newVal, oldVal) {
 					pieChart.update(newVal);
-
-					// this is needed or the last value won't be updated
-					if(timer) {
-						$timeout.cancel(timer);
-					}
-					timer = $timeout(function() {
-						pieChart.update(scope.percent);
-					}, 1000 / 60);
 				});
 			}
 		};


### PR DESCRIPTION
scope.$watch()'s callback is function(newVal, oldVal), not function(oldVal, newVal). With the arguments in order, $timeout is not needed.
