### PR TITLE
Add a Total option, jquery.easypiechart.js

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
+> Modified version that add the option to set the total value. So you can build pies with any units. (days, hours, %,...)
+
 # easyPieChart
 
 > Lightweight plugin to render simple, animated and retina optimized pie charts

--- a/dist/jquery.easypiechart.js
+++ b/dist/jquery.easypiechart.js
@@ -183,7 +183,7 @@ var CanvasRenderer = function(el, options) {
 		}
 
 		// draw bar
-		drawCircle(color, options.lineWidth, percent / 100);
+		drawCircle(color, options.lineWidth, percent / options.total);
 	}.bind(this);
 
 	/**
@@ -212,6 +212,7 @@ var CanvasRenderer = function(el, options) {
 
 var EasyPieChart = function(el, opts) {
 	var defaultOptions = {
+		total: 100,
 		barColor: '#ef1e25',
 		trackColor: '#f9f9f9',
 		scaleColor: '#dfe0e0',

--- a/docs/options.md
+++ b/docs/options.md
@@ -11,6 +11,11 @@ You can pass these options to the initialize function to set a custom look and f
         <td>#ef1e25</td>
         <td>The color of the curcular bar. You can either pass a valid css color string, or a function that takes the current percentage as a value and returns a valid css color string.</td>
     </tr>
+     <tr>
+        <td><strong>total</strong></td>
+        <td>100</td>
+        <td>The total value of the chart. To customize the unit suffix displayed, see draw callback in your script</td>
+    </tr>
     <tr>
         <td><strong>trackColor</strong></td>
         <td>#f2f2f2</td>


### PR DESCRIPTION
Added a Total option to give users the ability to create per 100, per 24, per 60, per 365, etc. charts.

I only updated jquery.easypiechart.js in dist folder. Not really sure if I can update the other files myself without messing the whole thing up.

Currently unit suffix "%" is handled by css, but this would be better in another new option. Like "prefix" and "suffix" options.
