### PR TITLE
Add packaging for Meteor.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-module.exports = function(grunt) {
+module.exports = function (grunt) {
 
 	grunt.initConfig({
 
@@ -20,7 +20,8 @@ module.exports = function(grunt) {
 
 		clean: {
 			all: ['<%= dirs.dest %>/', '<%= dirs.tmp %>/'],
-			tmp: ['<%= dirs.tmp %>/']
+			tmp: ['<%= dirs.tmp %>/'],
+			meteor: ['.build.*', 'versions.json']
 		},
 
 		concat: {
@@ -53,13 +54,13 @@ module.exports = function(grunt) {
 			options: {
 				position: 'top',
 				banner: '/**!\n' +
-						' * <%= pkg.name %>\n' +
-						' * <%= pkg.description %>\n' +
-						' *\n' +
-						' * @license <%= pkg.license %>\n'+
-						' * @author <%= pkg.author.name %> <<%= pkg.author.email %>> (<%= pkg.author.url %>)\n' +
-						' * @version <%= pkg.version %>\n' +
-						' **/\n'
+					' * <%= pkg.name %>\n' +
+					' * <%= pkg.description %>\n' +
+					' *\n' +
+					' * @license <%= pkg.license %>\n' +
+					' * @author <%= pkg.author.name %> <<%= pkg.author.email %>> (<%= pkg.author.url %>)\n' +
+					' * @version <%= pkg.version %>\n' +
+					' **/\n'
 			},
 			files: {
 				src: [
@@ -165,11 +166,23 @@ module.exports = function(grunt) {
 					global: ['angular']
 				}
 			}
+		},
+
+		exec: {
+			'meteor-init': {
+				command: [
+          'type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }'
+        ].join(';')
+			},
+			'meteor-publish': {
+				command: 'meteor publish'
+			}
 		}
 	});
 
 	// load all installed grunt tasks
 	require('load-grunt-tasks')(grunt);
+	grunt.loadNpmTasks('grunt-exec');
 
 	// task defiinitions
 	grunt.registerTask('default', [
@@ -185,4 +198,6 @@ module.exports = function(grunt) {
 
 	grunt.registerTask('test', ['karma:unit']);
 	grunt.registerTask('all', ['default', 'less']);
+	grunt.registerTask('meteor-publish', ['exec:meteor-init', 'exec:meteor-publish', 'exec:meteor-cleanup']);
+	grunt.registerTask('meteor', ['exec:meteor-init', 'exec:meteor-publish', 'exec:meteor-cleanup']);
 };

--- a/package.js
+++ b/package.js
@@ -3,18 +3,17 @@ Package.describe({
 	version: '2.1.6',
 	summary: 'Meteor package for jQuery easyPieChart plugin!',
 	git: 'https://github.com/dotansimha/easy-pie-chart.git',
-	documentation: 'Readme.md'
+	documentation: null
 });
 
 Package.onUse(function (api) {
 	api.versionsFrom('METEOR@0.9.0.1');
     api.use('jquery', 'client');
 
-	api.add_files(['jquery.easypiechart.js'], 'client');
+	api.add_files(['dist/jquery.easypiechart.js'], 'client');
 });
 
 Package.onTest(function (api) {
 	api.use('tinytest');
 	api.use('rendro:easy-pie-chart');
-	api.addFiles('easy-pie-chart-tests.js');
 });

--- a/package.js
+++ b/package.js
@@ -1,0 +1,20 @@
+Package.describe({
+	name: 'rendro:easy-pie-chart',
+	version: '2.1.6',
+	summary: 'Meteor package for jQuery easyPieChart plugin!',
+	git: 'https://github.com/dotansimha/easy-pie-chart.git',
+	documentation: 'Readme.md'
+});
+
+Package.onUse(function (api) {
+	api.versionsFrom('METEOR@0.9.0.1');
+    api.use('jquery', 'client');
+
+	api.add_files(['jquery.easypiechart.js'], 'client');
+});
+
+Package.onTest(function (api) {
+	api.use('tinytest');
+	api.use('rendro:easy-pie-chart');
+	api.addFiles('easy-pie-chart-tests.js');
+});

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "grunt-umd": "~1.7.3",
     "requirejs": "~2.1.10",
     "grunt-readme": "~0.4.5",
-    "load-grunt-tasks": "~0.4.0"
+    "load-grunt-tasks": "~0.4.0",
+    "grunt-exec": "^0.4.6",
+    "spacejam": "^1.1.1"
   }
 }


### PR DESCRIPTION
Hi @rendro,

I'm a package maintainer for Meteor.js, a popular full-stack JavaScript framework.
I'm also a developer on angular-meteor, a library that let's you work with AngularJS on top of Meteor.

A lot of our users use easyPieChart and it right now there is a separate package and Github repo that simply manually copies your distribution and publish it to Meteor.
This PR will allow you to directly publish updated versions of easy-pie-chart as they become available. All you have to do is create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and I'll add you as a maintainer to the "rendro" organization there.

I've already published the current version of the package on Atmosphere (Meteor's package directory). When you release new versions of easy-pie-chart, you'll be able to publish them to Atmosphere by running "grunt meteor-publish".

Thanks & best regards,
Dotan.
