### PR TITLE
Check type of G_vmlCanvasManager.

### DIFF
--- a/src/renderer/canvas.js
+++ b/src/renderer/canvas.js
@@ -9,7 +9,7 @@ var CanvasRenderer = function(el, options) {
 
 	el.appendChild(canvas);
 
-	if (typeof(G_vmlCanvasManager) !== 'undefined') {
+	if (typeof(G_vmlCanvasManager) == 'object') {
 		G_vmlCanvasManager.initElement(canvas);
 	}
 

--- a/src/renderer/canvas.js
+++ b/src/renderer/canvas.js
@@ -9,7 +9,7 @@ var CanvasRenderer = function(el, options) {
 
 	el.appendChild(canvas);
 
-	if (typeof(G_vmlCanvasManager) == 'object') {
+	if (typeof(G_vmlCanvasManager) === 'object') {
 		G_vmlCanvasManager.initElement(canvas);
 	}
 


### PR DESCRIPTION
Actual example of a problematic case is ``typeof(G_vmlCanvasManager) == false``.