### PR TITLE
add setOptions function, revised update function to allow for new options

### DIFF
--- a/src/easypiechart.js
+++ b/src/easypiechart.js
@@ -99,10 +99,24 @@ var EasyPieChart = function(el, opts) {
 	/**
 	 * Update the value of the chart
 	 * @param  {number} newValue Number between 0 and 100
+	 * @param  {newOptions} newOptions chart options
 	 * @return {object}          Instance of the plugin for method chaining
 	 */
-	this.update = function(newValue) {
-		newValue = parseFloat(newValue);
+	this.update = function(newValue, newOptions) {
+	    newValue = parseFloat(newValue);
+	    console.log(newOptions);
+	    if (newOptions != null) {
+	        // merge user options into default options
+	        for (var i in defaultOptions) {
+	            if (defaultOptions.hasOwnProperty(i)) {
+	                options[i] = newOptions && typeof (newOptions[i]) !== 'undefined' ? newOptions[i] : defaultOptions[i];
+	                if (typeof (options[i]) === 'function') {
+	                    options[i] = options[i].bind(this);
+	                }
+	            }
+	        }
+	    }
+
 		if (options.animate.enabled) {
 			this.renderer.animate(currentValue, newValue);
 		} else {

--- a/src/easypiechart.js
+++ b/src/easypiechart.js
@@ -97,25 +97,15 @@ var EasyPieChart = function(el, opts) {
 	}.bind(this);
 
 	/**
-	 * Update the value of the chart
+	 * Update the chart value and options
 	 * @param  {number} newValue Number between 0 and 100
 	 * @param  {newOptions} newOptions chart options
 	 * @return {object}          Instance of the plugin for method chaining
 	 */
 	this.update = function(newValue, newOptions) {
 	    newValue = parseFloat(newValue);
-	    console.log(newOptions);
-	    if (newOptions != null) {
-	        // merge user options into default options
-	        for (var i in defaultOptions) {
-	            if (defaultOptions.hasOwnProperty(i)) {
-	                options[i] = newOptions && typeof (newOptions[i]) !== 'undefined' ? newOptions[i] : defaultOptions[i];
-	                if (typeof (options[i]) === 'function') {
-	                    options[i] = options[i].bind(this);
-	                }
-	            }
-	        }
-	    }
+	    
+	    this.setOptions(newOptions);
 
 		if (options.animate.enabled) {
 			this.renderer.animate(currentValue, newValue);
@@ -126,7 +116,16 @@ var EasyPieChart = function(el, opts) {
 		return this;
 	}.bind(this);
 
-	/**
+        /**
+	 * Update options
+	 * @param newOptions
+	 * @returns {EasyPieChart}
+	 */
+	this.setOptions = function (newOptions) {
+	   		$.extend(true, options, newOptions);
+	    		return this;
+	    	};	
+	 /**
 	 * Disable animation
 	 * @return {object} Instance of the plugin for method chaining
 	 */


### PR DESCRIPTION
Added a setOptions function and revised the update function to allow for new options to be passed to the chart.
Example.

``` javascript
 $('#modalChart').data('easyPieChart').update(chartPercent, {
                    scaleColor: false,
                    barColor: chartBarColor,
                    trackColor: '#ccc'
                });
```
