### PR TITLE
Fix undefined values prevent future updates

### DIFF
--- a/src/easypiechart.js
+++ b/src/easypiechart.js
@@ -103,6 +103,9 @@ var EasyPieChart = function(el, opts) {
 	 */
 	this.update = function(newValue) {
 		newValue = parseFloat(newValue);
+		if (isNaN(newValue)) {
+			newValue = 0;
+		}
 		if (options.animate.enabled) {
 			this.renderer.animate(currentValue, newValue);
 		} else {


### PR DESCRIPTION
Any unparsable value that results in a NaN such as "undefined" will cause the chart to disappear.  But if the value is updated to a proper numerical value the chart does not redraw and animate correctly.

This fix defaults NaN values to 0.  This will allow to chart to function properly regardless of the value and puts the responsibility back on the caller to hide or show the chart according to their own logic and business needs.
