### PR TITLE
Added class name for canvas for CSS accessibility

### DIFF
--- a/dist/jquery.easypiechart.js
+++ b/dist/jquery.easypiechart.js
@@ -40,6 +40,7 @@ var CanvasRenderer = function(el, options) {
 
 	var ctx = canvas.getContext('2d');
 
+	canvas.className = 'easy-pie-canvas';
 	canvas.width = canvas.height = options.size;
 
 	// canvas on retina devices


### PR DESCRIPTION
I added the `easy-pie-canvas` class name to the `canvas` elements created by `easy-pie-chart` so that users can easily access and edit CSS for the pie charts.

I had the problem of not being able to edit the size of the pie chart, and this allows me to access all pie chart canvas simply with `$(".easy-pie-canvas")`.  